### PR TITLE
Feature/enable compose

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,15 +71,13 @@ dependencies {
     debugImplementation 'androidx.compose.ui:ui-test-manifest'
 
 
-//    observer を複数ラップできるらしい
-    def libVersion = "1.3.0"
-    implementation "com.github.hadilq:live-event:$libVersion"
 //    room
-    implementation("androidx.room:room-runtime:2.4.3")
-    annotationProcessor("androidx.room:room-compiler:2.4.3")
-    kapt("androidx.room:room-compiler:2.4.3")
-    implementation 'androidx.room:room-ktx:2.4.3'
-    kapt "androidx.room:room-compiler:2.4.3"
+    def room_version = "2.5.0"
+    implementation("androidx.room:room-runtime:$room_version")
+    annotationProcessor("androidx.room:room-compiler:$room_version")
+    kapt("androidx.room:room-compiler:$room_version")
+    implementation ("androidx.room:room-ktx:$room_version")
+    kapt "androidx.room:room-compiler:$room_version"
     def lifecycle_version = "2.6.0-alpha03"
 
     // ViewModel

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     // LiveData
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
 //    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
 //    implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
     implementation 'androidx.recyclerview:recyclerview-selection:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.20"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     kapt("androidx.room:room-compiler:$room_version")
     implementation ("androidx.room:room-ktx:$room_version")
     kapt "androidx.room:room-compiler:$room_version"
-    def lifecycle_version = "2.6.0-alpha03"
+    def lifecycle_version = "2.5.1"
 
     // ViewModel
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,7 +95,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 
     implementation 'androidx.recyclerview:recyclerview-selection:1.1.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,12 +36,16 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.3.2"
+    }
     kotlinOptions {
         jvmTarget = '1.8'
     }
     buildFeatures {
         viewBinding true
         dataBinding true
+        compose true
     }
     viewBinding{
        true
@@ -54,14 +58,18 @@ android {
 }
 
 dependencies {
-//    非同期処理の話
-//    implementation 'io.reactivex.rxjava2:rxjava:2.2.9'
-//    implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
-//    implementation 'io.reactivex.rxjava2:rxkotlin:2.2.0'
-//    // https://mvnrepository.com/artifact/androidx.room/room-rxjava2
-//    runtimeOnly("androidx.room:room-rxjava2:2.4.3")
-//    def roomVersion = "2.4.3"
-//    implementation("androidx.room:room-rxjava2:2.4.3")
+    // compose
+    def composeBom = platform('androidx.compose:compose-bom:2022.12.00')
+    implementation composeBom
+    androidTestImplementation composeBom
+    implementation 'androidx.compose.material3:material3'
+    // Android Studio Preview support
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+    // UI Tests
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest'
+
 
 //    observer を複数ラップできるらしい
     def libVersion = "1.3.0"

--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,10 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        def nav_version = "2.4.2"
+        def nav_version = "2.5.3"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.gms:google-services:4.3.14'
+        classpath 'com.google.gms:google-services:4.3.15'
     }
 }
 plugins {


### PR DESCRIPTION
implemented for compose
updated existing implements
I actually wanted to update kotlin version to 1.8.0 but it seems that this version is not supported by compose(?)
and lifecycle version 2.6.0-alpha03 caused duplicated classes error. 
so I changed to the stable 2.5.0 version then the error disappeared
